### PR TITLE
Work around mod conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ hoses affects your pump time.
 
 ## Known conflicts
 
-* [Contact modder] [3rd Person](https://www.farming-simulator.com/mod.php?mod_id=234226)
+* [Contact modder/Worked around] [3rd Person](https://www.farming-simulator.com/mod.php?mod_id=234226)
   * Unfortunately, that mod replaces the Player.update() code, breaking any mods that depend on/add to that call. Contact the modder to mention that Utilly functions such as `overwriteFunction` and `appendedFunction` should be used instead.
-* [Contact modder]  [Precision Hands](https://www.farming-simulator.com/mod.php?mod_id=265312)
+  This has now been worked around. However, the 3rd Person mod in its current state replaces any fixes done by Giants in the future, therefore the modder should still be contacted.
+* [Contact modder/Worked around]  [Precision Hands](https://www.farming-simulator.com/mod.php?mod_id=265312)
   * Sadly, that mod does not overwrite the Player.pickUpObject() function correctly by not calling the superFunc, therefor making the hose grap and drop functions unreachable. Contact the modder to mention that the superFunc should be called to maintain comptible with other any other mod relaying on that function.
+  This has now been worked around. However, the Precision Hands mod in its current state replaces any fixes done by Giants in the future, therefore the modder should still be contacted.
 * [Fixed] [Mobile Workshop](https://www.farming-simulator.com/mod.php?mod_id=225545)
   * Removed obsolete FS19 code in Manure System, please download the latest version of the Manure System
 

--- a/src/hose/HosePlayer.lua
+++ b/src/hose/HosePlayer.lua
@@ -23,13 +23,19 @@ function HosePlayer.new(isClient, isServer, mission, input)
 
     Player.readUpdateStream = Utils.appendedFunction(Player.readUpdateStream, HosePlayer.inj_player_readUpdateStream)
     Player.writeUpdateStream = Utils.appendedFunction(Player.writeUpdateStream, HosePlayer.inj_player_writeUpdateStream)
-    Player.update = Utils.appendedFunction(Player.update, HosePlayer.inj_player_update)
     Player.onLeave = Utils.appendedFunction(Player.onLeave, HosePlayer.inj_player_onLeave)
+
+    -- Workaround for mod conflicts caused by Precision Hands and 3rdPerson mods:
+    -- Delay the method override so the other mods can't replace our code.
+    Mission00.loadMission00Finished = Utils.appendedFunction(Mission00.loadMission00Finished, function(...)
+        Player.update = Utils.appendedFunction(Player.update, HosePlayer.inj_player_update)
+        Player.pickUpObject = Utils.overwrittenFunction(Player.pickUpObject, HosePlayer.inj_player_pickUpObject)
+    end)
 
     Player.updateActionEvents = Utils.appendedFunction(Player.updateActionEvents, HosePlayer.inj_player_updateActionEvents)
     Player.registerActionEvents = Utils.prependedFunction(Player.registerActionEvents, HosePlayer.inj_player_registerActionEvents)
 
-    Player.pickUpObject = Utils.overwrittenFunction(Player.pickUpObject, HosePlayer.inj_player_pickUpObject)
+
 
     Player.checkObjectInRange = Utils.overwrittenFunction(Player.checkObjectInRange, HosePlayer.inj_player_checkObjectInRange)
     PlayerStateThrow.isAvailable = Utils.overwrittenFunction(PlayerStateThrow.isAvailable, HosePlayer.inj_playerStateThrow_isAvailable)


### PR DESCRIPTION
This commit works around the fact that the 3rd Person and Precision Hands mods replace base game behavior rather than extending it. The other mods should still be fixed since they will still break a lot of other things.